### PR TITLE
Implentação do endpoint GET /deputados com paginação e validações

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,2 @@
 PORT=3000  # Porta em que o servidor backend irá rodar
+NODE_ENV=development  # Ambiente de execução (development ou production)

--- a/backend/src/controllers/DeputadosController.js
+++ b/backend/src/controllers/DeputadosController.js
@@ -13,6 +13,26 @@ class DeputadosController {
         if(!/^\d+$/.test(limit) || !/^\d+$/.test(offset)) {
             throw new AppError("Parâmetros 'limit' e 'offset' devem ser números inteiros positivos", 400);
         }
+
+        try {
+            const {total} = await knex("deputados").count('* as total').first();
+
+            const deputados = await knex("deputados")
+                                    .orderBy("nome")
+                                    .limit(limit)
+                                    .offset(offset)
+                                    .select("id", "nome", "partido", "sigla_uf", "url_foto", "email", "data_nascimento");
+            
+            return response.json({
+                dados: deputados,
+                total: total,
+                limit: parseInt(limit),
+                offset: parseInt(offset)
+            });
+        }
+        catch (error) {
+            throw new Error(`ERROR (DeputadosController/index): Erro ao buscar deputados: ${error.message}`);
+        }
     }
     
     async show(request, response) {

--- a/backend/src/controllers/DeputadosController.js
+++ b/backend/src/controllers/DeputadosController.js
@@ -1,8 +1,20 @@
 const AppError = require('../utils/AppError');
 const {getDetailsDeputadoById} = require('../services/camara.service');
+const knex = require('../database/knex'); // Assuming you have a knex instance set up for database access
 
 class DeputadosController {
 
+    async index(request, response) {
+
+        const limit = request.query.limit || 20;
+        const offset = request.query.offset || 0;
+
+        //  Verifica se os parâmetros limit e offset são números inteiros positivos
+        if(!/^\d+$/.test(limit) || !/^\d+$/.test(offset)) {
+            throw new AppError("Parâmetros 'limit' e 'offset' devem ser números inteiros positivos", 400);
+        }
+    }
+    
     async show(request, response) {
         const { id } = request.params;
         const deputado = await getDetailsDeputadoById(id);

--- a/backend/src/controllers/DeputadosController.spec.js
+++ b/backend/src/controllers/DeputadosController.spec.js
@@ -129,5 +129,19 @@ describe('DeputadosController', () => {
                 expect(error.statusCode).toBe(400);
             }
         });
+
+        it('deve lançar erro se ocorer na consulta ao banco de dados', async () => {
+            knexMockFn("deputados").count.mockImplementation(() => {
+                throw new Error('tabela não encontrada');
+            });
+
+            const request = { query: { limit: '2', offset: '0' } };
+            
+            try {
+                await controller.index(request, response);
+            } catch (error) {
+                expect(error.message).toBe('ERROR (DeputadosController/index): Erro ao buscar deputados: tabela não encontrada');
+            }
+        });
     });
 });

--- a/backend/src/controllers/DeputadosController.spec.js
+++ b/backend/src/controllers/DeputadosController.spec.js
@@ -94,5 +94,17 @@ describe('DeputadosController', () => {
                 offset: 0
             });
         });
+
+        it('deve lançar erro se limit ou offset forem uma string não numérica', async () => {
+            const request = { query: { limit: 'abc', offset: '0' } };
+            
+            try {
+                await controller.index(request, response);
+            } catch (error) {
+                expect(error).toBeInstanceOf(AppError);
+                expect(error.message).toBe("Parâmetros 'limit' e 'offset' devem ser números inteiros positivos");
+                expect(error.statusCode).toBe(400);
+            }
+        });
     });
 });

--- a/backend/src/controllers/DeputadosController.spec.js
+++ b/backend/src/controllers/DeputadosController.spec.js
@@ -4,16 +4,29 @@ const AppError = require('../utils/AppError');
 
 jest.mock('../services/camara.service');
 
+
+const mockKnexInstance = {
+    count: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    select: jest.fn(),
+    first: jest.fn()
+};
+
+jest.mock("../database/knex", () => jest.fn((tableName) => mockKnexInstance)) ;
+
 describe('DeputadosController', () => {
     let request, response;
 
-    beforeEach(() => {
-        request = { params: { id: '204555' } };
-        response = { json: jest.fn() };
-    });
+    describe('Metodo show', () => {
 
-    describe('show', () => {
+        beforeEach(() => {
+            request = { params: { id: '204555' } };
+            response = { json: jest.fn() };
+        });
 
+        
         it('deve retornar os dados do deputado quando encontrado', async () => {
             const mockDeputado = { id: 204555, nome: 'Marcos Pereira' };
             getDetailsDeputadoById.mockResolvedValue(mockDeputado);
@@ -34,6 +47,52 @@ describe('DeputadosController', () => {
                 expect(err.message).toBe('Deputado não encontrado');
                 expect(err.statusCode).toBe(400);
             }
+        });
+    
+    });
+
+    describe('Metodo index', () => {
+        
+        let controller;
+        let knexMockFn;
+        let response;
+
+        beforeEach(() => {
+            controller = new DeputadosController();
+            knexMockFn = require('../database/knex');
+            response = { json: jest.fn() };
+            jest.clearAllMocks();
+        });
+
+        it('deve retornar lista de deputados com total, limit e offset', async () => {
+
+            mockKnexInstance.first.mockResolvedValue({ total: 2 });
+
+            mockKnexInstance.orderBy("nome").limit(2).offset(0).select.mockResolvedValue([
+                { id: 1, nome: 'Deputado 1', partido: 'ABC', sigla_uf: 'PE', url_foto: '', email: '', data_nascimento: '1980-01-01' },
+                { id: 2, nome: 'Deputado 2', partido: 'DEF', sigla_uf: 'SP', url_foto: '', email: '', data_nascimento: '1985-01-01' }
+            ]);
+
+            const request = { query: { limit: '2', offset: '0' } };
+
+            await controller.index(request, response);
+            
+            expect(knexMockFn("deputados").count).toHaveBeenCalledWith('* as total');
+            expect(await knexMockFn("deputados").count("* as total").first()).toEqual({total: 2});
+            expect(knexMockFn("deputados").orderBy).toHaveBeenCalledWith("nome");
+            expect(knexMockFn("deputados").limit).toHaveBeenCalledWith(2);
+            expect(knexMockFn("deputados").offset).toHaveBeenCalledWith(0);
+            expect(knexMockFn("deputados").select).toHaveBeenCalledWith("id", "nome", "partido", "sigla_uf", "url_foto", "email", "data_nascimento");
+
+            expect(response.json).toHaveBeenCalledWith({
+                dados: [
+                    { id: 1, nome: 'Deputado 1', partido: 'ABC', sigla_uf: 'PE', url_foto: '', email: '', data_nascimento: '1980-01-01' },
+                    { id: 2, nome: 'Deputado 2', partido: 'DEF', sigla_uf: 'SP', url_foto: '', email: '', data_nascimento: '1985-01-01' }
+                ],
+                total: 2,
+                limit: 2,
+                offset: 0
+            });
         });
     });
 });

--- a/backend/src/controllers/DeputadosController.spec.js
+++ b/backend/src/controllers/DeputadosController.spec.js
@@ -106,5 +106,28 @@ describe('DeputadosController', () => {
                 expect(error.statusCode).toBe(400);
             }
         });
+
+        it('deve lançar erro se limit ou offset forem negativos', async () => {
+            const request = { query: { limit: '10', offset: '-1' } };
+            
+            try {
+                await controller.index(request, response);
+            } catch (error) {
+                expect(error).toBeInstanceOf(AppError);
+                expect(error.message).toBe("Parâmetros 'limit' e 'offset' devem ser números inteiros positivos");
+                expect(error.statusCode).toBe(400);
+            }
+        });
+
+        it('deve lançar erro se limit ou offser não forem inteiros', async () => {
+            const request = { query: { limit: '2.5', offset: '0' } };
+            try {
+                await controller.index(request, response);
+            } catch (error) {
+                expect(error).toBeInstanceOf(AppError);
+                expect(error.message).toBe("Parâmetros 'limit' e 'offset' devem ser números inteiros positivos");
+                expect(error.statusCode).toBe(400);
+            }
+        });
     });
 });

--- a/backend/src/database/knex/index.js
+++ b/backend/src/database/knex/index.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 const config = require("../../../knexfile");
 const knex = require("knex");
 

--- a/backend/src/routes/deputados.routes.js
+++ b/backend/src/routes/deputados.routes.js
@@ -5,6 +5,7 @@ const deputadosRoutes = Router();
 const deputadosController = new DeputadosController();
 
 // Rota para buscar todos os deputados com paginação
+deputadosRoutes.get('/', deputadosController.index);
 deputadosRoutes.get('/:id', deputadosController.show);
 
 module.exports = deputadosRoutes;


### PR DESCRIPTION
## 🎯 Objetivo

Implementar o endpoint `GET /deputados` para listar os parlamentares armazenados no banco de dados, com suporte a paginação via parâmetros `offset` e `limit`.

## ✅ Alterações realizadas

* chore: adiciona variável `NODE_ENV` ao arquivo `.env.example` e organiza variáveis
* feat: adição de rota `GET /deputados`
* feat: adiciona método `index` ao `DeputadosController` com validação de parâmetros
* feat: implementa lógica de busca e retorno paginado dos deputados
* test: adiciona testes para:

  * retorno correto dos deputados
  * erro ao passar `limit` ou `offset` como string
  * erro ao passar `limit` ou `offset` como valores negativos ou não inteiros
  * erro ao simular falha na consulta à tabela de deputados

## 📎 Issue relacionada

Sub-issue (Backend): Criar endpoint GET /deputados com paginação (offset, limit)
Closes #11

## 📜 Regras de Negócio implementadas

* `offset` e `limit` são opcionais, mas devem ser inteiros positivos caso fornecidos
* Valores inválidos lançam erro com status `400`
* Em caso de ausência de parâmetros válidos, o `limit` padrão é `20` e `offset` é `0`
* Os seguintes campos são retornados para cada deputado:

  * `id`, `nome`, `partido`, `url_partido`, `sigla_uf`, `id_legislatura`, `url_foto`, `email`, `data_nascimento`

## 🧪 Testes

* ✅ Retorno correto de deputados paginados
* ✅ Erro ao fornecer `limit` ou `offset` como strings inválidas
* ✅ Erro ao fornecer valores negativos ou não inteiros
* ✅ Simulação de erro interno no acesso à tabela de deputados

## 📝 Observações

A implementação mantém a separação entre as camadas de rota, controller e regra de negócio, garantindo testes unitários com cobertura para cenários de sucesso e erro.