### PR TITLE
Implementação do endpoint GET /deputados/search com filtros, paginação e validações

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/jest": "^30.0.0",
         "axios": "^1.10.0",
+        "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-async-error": "^0.0.2",
@@ -2453,6 +2454,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/cross-spawn": {
@@ -5370,6 +5384,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@types/jest": "^30.0.0",
     "axios": "^1.10.0",
+    "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-async-error": "^0.0.2",

--- a/backend/src/routes/deputados.routes.js
+++ b/backend/src/routes/deputados.routes.js
@@ -6,6 +6,7 @@ const deputadosController = new DeputadosController();
 
 // Rota para buscar todos os deputados com paginação
 deputadosRoutes.get('/', deputadosController.index);
+deputadosRoutes.get('/search', deputadosController.search);
 deputadosRoutes.get('/:id', deputadosController.show);
 
 module.exports = deputadosRoutes;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,9 +4,11 @@ require("express-async-error");
 const express = require('express');
 const errorHandler = require('./middlewares/errorHandler');
 const routes = require('./routes');
+const cors = require('cors');
 
 const app = express();
 app.use(express.json());
+app.use(cors());
 
 app.use(routes);
 

--- a/backend/src/utils/AppError.js
+++ b/backend/src/utils/AppError.js
@@ -1,9 +1,6 @@
-class AppError {
-    message;
-    statusCode;
-    
+class AppError extends Error {
     constructor(message, statusCode = 400) {
-        this.message = message;
+        super(message);
         this.statusCode = statusCode;
     }
 }

--- a/backend/src/utils/validarPartido.js
+++ b/backend/src/utils/validarPartido.js
@@ -1,0 +1,19 @@
+const knex = require('../database/knex');
+const AppError = require('../utils/AppError');
+
+async function validarPartido(partido) {
+    if (!/^[A-Z]{2,5}$/.test(partido)) {
+        throw new AppError("Parâmetro 'partido' inválido", 400);
+    }
+
+    const partidosDb = await knex("deputados").distinct("partido");
+    const partidos_validos = partidosDb.map(p => p.partido);
+
+    if (!partidos_validos.includes(partido)) {
+        throw new AppError("Partido não encontrado", 400);
+    }
+
+    return true;
+}
+
+module.exports = validarPartido;

--- a/backend/src/utils/validarPartido.spec.js
+++ b/backend/src/utils/validarPartido.spec.js
@@ -1,0 +1,41 @@
+const validarPartido = require('./validarPartido');
+const AppError = require('../utils/AppError');
+
+jest.mock('../database/knex', () => {
+    return jest.fn( () => ({
+        distinct: jest.fn().mockResolvedValue([{ partido: 'PT' }, { partido: 'PSDB' }])
+    }))
+});
+
+const knex = require('../database/knex');
+
+describe('validarPartido', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('deve retornar true para partido válido presente no banco', async () => {
+        const resultado = await validarPartido('PT');
+        expect(resultado).toBe(true);
+    });
+
+    it('deve lançar erro para partido com formato inválido', async () => {
+        await expect(validarPartido('P1')).rejects.toThrow(AppError);
+        await expect(validarPartido('')).rejects.toThrow(AppError);
+        await expect(validarPartido('PARTIDO_MUITO_GRANDE')).rejects.toThrow(AppError);
+    });
+
+    it('deve lançar erro para partido não cadastrado no banco', async () => {
+        knex.mockImplementation(() => ({
+            distinct: jest.fn().mockResolvedValue([{ partido: 'PT' }, { partido: 'PSDB' }])
+        }));
+        await expect(validarPartido('MDB')).rejects.toThrow(AppError);
+    });
+
+    it('deve chamar o banco apenas se o formato for válido', async () => {
+        const distinctMock = jest.fn().mockResolvedValue([{ partido: 'PT' }]);
+        knex.mockImplementation(() => ({ distinct: distinctMock }));
+        await expect(validarPartido('P1')).rejects.toThrow(AppError);
+        expect(distinctMock).not.toHaveBeenCalled();
+    });
+});

--- a/backend/src/utils/validarSiglaUf.js
+++ b/backend/src/utils/validarSiglaUf.js
@@ -1,0 +1,19 @@
+const knex = require("../database/knex");
+const AppError = require("../utils/AppError");
+
+async function validarSiglaUf(siglaUf) {
+    if (!/^[A-Z]{2}$/.test(siglaUf)) {
+        throw new AppError("Parâmetro 'uf' inválido", 400);
+    }
+
+    const estadosDb = await knex("deputados").distinct("sigla_uf");
+    const estados_validos = estadosDb.map(e => e.sigla_uf);
+
+    if (!estados_validos.includes(siglaUf)) {
+        throw new AppError("Estado não encontrado", 400);
+    }
+
+    return true;
+}
+
+module.exports = validarSiglaUf;

--- a/backend/src/utils/validarSiglaUf.spec.js
+++ b/backend/src/utils/validarSiglaUf.spec.js
@@ -1,0 +1,40 @@
+const validarSiglaUf = require('./validarSiglaUf');
+const AppError = require('../utils/AppError');
+
+jest.mock('../database/knex', () => {
+    return jest.fn(() => ({
+        distinct: jest.fn().mockResolvedValue([{ sigla_uf: 'PE' }, { sigla_uf: 'SP' }])
+    }));
+});
+const knex = require('../database/knex');
+
+describe('validarSiglaUf', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('deve retornar true para sigla válida presente no banco', async () => {
+        const resultado = await validarSiglaUf('PE');
+        expect(resultado).toBe(true);
+    });
+
+    it('deve lançar erro para sigla com formato inválido', async () => {
+        await expect(validarSiglaUf('P3')).rejects.toThrow(AppError);
+        await expect(validarSiglaUf('')).rejects.toThrow(AppError);
+        await expect(validarSiglaUf('PERNAMBUCO')).rejects.toThrow(AppError);
+    });
+
+    it('deve lançar erro para sigla não cadastrada no banco', async () => {
+        knex.mockImplementation(() => ({
+            distinct: jest.fn().mockResolvedValue([{ sigla_uf: 'PE' }, { sigla_uf: 'SP' }])
+        }));
+        await expect(validarSiglaUf('RU')).rejects.toThrow(AppError);
+    });
+
+    it('deve chamar o banco apenas se o formato for válido', async () => {
+        const distinctMock = jest.fn().mockResolvedValue([{ sigla_uf: 'PE' }]);
+        knex.mockImplementation(() => ({ distinct: distinctMock }));
+        await expect(validarSiglaUf('P3')).rejects.toThrow(AppError);
+        expect(distinctMock).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## 🎯 **Objetivo**

Implementar o endpoint `GET /deputados/search` com suporte a filtros por nome, partido e UF, além de paginação e validações específicas dos parâmetros.


## ✅ **Alterações realizadas**

* `feat`: adiciona rota `GET /deputados/search`
* `feat`: adiciona método `search` ao `DeputadosController` com suporte a filtros dinâmicos
* `feat`: implementa validações de partido (`validarPartido`) e UF (`validarSiglaUf`)
* `refactor`: herda a classe `AppError` da classe nativa `Error` para melhor tratamento e rastreamento de erros
* `test`: adiciona testes para:

  * `validarPartido`
  * `validarSiglaUf`
  * método `search` do controller


## 📎 **Issue relacionada**

Sub-issue (Backend): Criar endpoint `GET /deputados/search`
Closes #4 


## 📜 **Regras de Negócio implementadas**

* Pelo menos um dos filtros `nome`, `partido` ou `uf` deve ser informado. Caso contrário, um erro com status **400** é lançado.
* Os filtros são:

  * `nome`: busca parcial e case-insensitive
  * `partido`: exige sigla válida e cadastrada no banco
  * `uf`: exige sigla válida de Unidade Federativa
* Suporte à paginação com `limit` e `offset`, com valores padrão de `20` e `0` respectivamente
* Parâmetros `limit` e `offset` devem ser inteiros positivos
* Os seguintes campos são retornados:

  * `id`, `nome`, `partido`, `sigla_uf`, `url_foto`, `email`, `data_nascimento`



## 🧪 **Testes**

✅ Validação de filtros por nome, partido e UF
✅ Retorno correto com múltiplos filtros aplicados
✅ Erro ao informar `limit` ou `offset` inválidos (strings, negativos ou decimais)

## 📝 **Observações**

* As funções `validarPartido` e `validarSiglaUf` foram desenvolvidas de forma isolada, com testes dedicados, e integradas ao controller via mocks nos testes unitários
* A estrutura do código segue o padrão de separação de responsabilidades por camadas (controller, service, utils)
* O uso da `AppError` centraliza e padroniza o lançamento de exceções em casos de entrada inválida


