### PR TITLE
Implementa filtros Listagem de despesas por deputado 

### DIFF
--- a/backend/src/controllers/DespesasController.js
+++ b/backend/src/controllers/DespesasController.js
@@ -1,29 +1,38 @@
 const validarIdDeputado = require('../utils/validarIdDeputado');
 const knex = require('../database/knex');
 const AppError = require('../utils/AppError');
+const validarSiglaUf = require('../utils/validarSiglaUf');
+const { validarLimitOffset, validarValores, validarTipo} = require('../utils/validarParametrosDespesas');
 
 class DespesasController {
 
     async index(request, response) {
-        const {deputado_id} = request.params;
-        await validarIdDeputado(deputado_id);
+        const { deputado_id } = request.params;
 
-        const limit = request.query.limit ? Number(request.query.limit) : 10;
-        const offset = request.query.offset ? Number(request.query.offset) : 0;
+        const { limit, offset, valor_min, valor_max, tipo, uf } = request.query;
 
-        const {total} = await knex('despesas').where('id_deputado', deputado_id).count('* as total').first();
+        validarIdDeputado(deputado_id);
+        validarLimitOffset(limit, offset);
+        validarValores(valor_min, valor_max);
+        validarTipo(tipo);
 
-        const despesas = await knex('despesas').select('descricao', 'valor_documento', 'data_emissao', 'fornecedor', 'sigla_uf')
-                                .where('id_deputado', deputado_id).orderBy('data_emissao', 'desc').limit(limit).offset(offset);
+        let query = knex("despesas").where({ id_deputado: deputado_id }).orderBy("data_emissao", "desc");
 
+        if (uf && await validarSiglaUf(uf)) query = query.where("sigla_uf", uf);
+        if (valor_min) query = query.where("valor_documento", ">=", valor_min);
+        if (valor_max) query = query.where("valor_documento", "<=", valor_max);
+        if (tipo) query = query.where("descricao", "like", `%${tipo}%`);
+
+        const despesas = await query.limit(limit).offset(offset);
+        const {total} = await query.clone().count('* as total').first();
+        
         response.json({
-            dados: despesas,
+            dados:despesas,
             total: total,
-            limit: limit,
-            offset: offset
+            limit: Number(limit),
+            offset: Number(offset) ? Number(offset) : 0 
         });
     }
-
 }
 
 module.exports = DespesasController;

--- a/backend/src/controllers/DespesasController.spec.js
+++ b/backend/src/controllers/DespesasController.spec.js
@@ -1,0 +1,156 @@
+const DespesasController = require('../controllers/DespesasController');
+const knex = require('../database/knex');
+const AppError = require('../utils/AppError');
+
+const {
+    validarLimitOffset,
+    validarValores,
+    validarTipo,
+} = require('../utils/validarParametrosDespesas');
+
+const validarIdDeputado = require('../utils/validarIdDeputado');
+const validarSiglaUf = require('../utils/validarSiglaUf');
+
+
+// Realizando o mock do knex e das funções de validação
+const mockKnexInstance = {
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    clone: jest.fn().mockReturnThis(),
+    count: jest.fn().mockReturnThis(),
+    first: jest.fn().mockReturnValue(Promise.resolve({ total: 2 })),
+    then: jest.fn() // será definido nos testes
+};
+
+jest.mock("../database/knex", () => jest.fn(() => mockKnexInstance));
+jest.mock('../utils/validarIdDeputado', () => jest.fn());
+jest.mock('../utils/validarSiglaUf', () => jest.fn(async () => true));
+jest.mock('../utils/validarParametrosDespesas', () => ({
+    validarLimitOffset: jest.fn(),
+    validarValores: jest.fn(),
+    validarTipo: jest.fn(),
+}));
+
+describe('DespesasController', () => {
+    describe("Método index", () => {
+        let request, response;
+
+        beforeEach(() => {
+            request = {
+                params: { deputado_id: '123' },
+                query: {
+                    limit: '10',
+                    offset: '0',
+                    valor_min: '100',
+                    valor_max: '1000',
+                    tipo: 'Hospedagem',
+                    uf: 'PE'
+                }
+            };
+            response = { json: jest.fn() };
+
+            // Limpa mocks
+            Object.values(mockKnexInstance).forEach(fn => {
+                if (typeof fn.mockClear === 'function') fn.mockClear();
+            });
+            validarIdDeputado.mockReset();
+            validarSiglaUf.mockReset();
+            validarLimitOffset.mockReset();
+            validarValores.mockReset();
+            validarTipo.mockReset();
+
+            // Simula retorno de despesas
+            mockKnexInstance.then = jest.fn((cb) => cb([
+                {
+                    id: 1,
+                    descricao: 'Hospedagem em Brasília',
+                    valor_documento: 500,
+                    data_emissao: '2024-05-15',
+                    sigla_uf: 'PE'
+                }
+            ]));
+            validarSiglaUf.mockResolvedValue(true);
+        });
+
+        it('deve retornar despesas filtradas com sucesso', async () => {
+            const controller = new DespesasController();
+            await controller.index(request, response);
+
+            expect(validarIdDeputado).toHaveBeenCalledWith('123');
+            expect(validarLimitOffset).toHaveBeenCalledWith('10', '0');
+            expect(validarValores).toHaveBeenCalledWith('100', '1000');
+            expect(validarTipo).toHaveBeenCalledWith('Hospedagem');
+            expect(validarSiglaUf).toHaveBeenCalledWith('PE');
+            expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+                dados: expect.any(Array),
+                total: 2,
+                limit: 10,
+                offset: 0
+            }));
+        });
+
+        it('deve lançar erro se deputado_id for inválido', async () => {
+            validarIdDeputado.mockImplementation(() => {
+                throw new AppError('ID inválido');
+            });
+            const controller = new DespesasController();
+            await expect(controller.index(request, response)).rejects.toThrow('ID inválido');
+        });
+
+        it('deve ignorar filtro de UF se inválida', async () => {
+            validarSiglaUf.mockResolvedValue(false);
+            const controller = new DespesasController();
+            await controller.index(request, response);
+            expect(validarSiglaUf).toHaveBeenCalledWith('PE');
+            expect(response.json).toHaveBeenCalled();
+        });
+
+        it('deve aplicar paginação corretamente', async () => {
+            const controller = new DespesasController();
+            await controller.index(request, response);
+            expect(mockKnexInstance.limit).toHaveBeenCalledWith('10');
+            expect(mockKnexInstance.offset).toHaveBeenCalledWith('0');
+        });
+
+        it('deve lançar erro se validarLimitOffset lançar', async () => {
+            validarLimitOffset.mockImplementation(() => { throw new AppError('erro', 400); });
+            const controller = new DespesasController();
+            await expect(controller.index(request, response)).rejects.toThrow(AppError);
+            expect(validarLimitOffset).toHaveBeenCalled();
+        });
+
+        it('deve lançar erro se validarValores lançar', async () => {
+            validarValores.mockImplementation(() => { throw new AppError('erro', 400); });
+            const controller = new DespesasController();
+            await expect(controller.index(request, response)).rejects.toThrow(AppError);
+            expect(validarValores).toHaveBeenCalled();
+        });
+
+        it('deve lançar erro se validarTipo lançar', async () => {
+            validarTipo.mockImplementation(() => { throw new AppError('erro', 400); });
+            const controller = new DespesasController();
+            await expect(controller.index(request, response)).rejects.toThrow(AppError);
+            expect(validarTipo).toHaveBeenCalled();
+        });
+
+        it('deve passar todos os filtros para o query', async () => {
+            request.query = { limit: '5', offset: '1', valor_min: '100', valor_max: '200', tipo: 'alimentação', uf: 'PE' };
+            const controller = new DespesasController();
+            await controller.index(request, response);
+            expect(validarLimitOffset).toHaveBeenCalledWith('5', '1');
+            expect(validarValores).toHaveBeenCalledWith('100', '200');
+            expect(validarTipo).toHaveBeenCalledWith('alimentação');
+        });
+
+        it('deve funcionar com filtros mínimos (apenas obrigatórios)', async () => {
+            request.query = { limit: '10', offset: '0' };
+            const controller = new DespesasController();
+            await controller.index(request, response);
+            expect(validarLimitOffset).toHaveBeenCalledWith('10', '0');
+            expect(validarValores).toHaveBeenCalledWith(undefined, undefined);
+            expect(validarTipo).toHaveBeenCalledWith(undefined);
+        });
+    });
+});

--- a/backend/src/utils/validarParametrosDespesas.js
+++ b/backend/src/utils/validarParametrosDespesas.js
@@ -1,0 +1,39 @@
+const AppError = require("../utils/AppError");
+
+function validarLimitOffset(limit, offset) {
+
+    limit = limit ? Number(limit) : 10; // valor padrão
+    offset = offset ? Number(offset) : 0; // valor padrão
+    
+    if (!/^\d+$/.test(limit) || !/^\d+$/.test(offset)) {
+        throw new AppError("Parâmetros 'limit' e 'offset' devem ser números inteiros positivos", 400);
+    }
+    return true;
+}
+
+function validarValores(valor_min, valor_max) {
+    if (valor_min && (Number(valor_min) < 0 || Number.isNaN(Number(valor_min)))) {
+        throw new AppError("Parâmetro 'valor_min' deve ser um número válido e positivo", 400);
+    }
+    if (valor_max && (Number(valor_max) < 0 || Number.isNaN(Number(valor_max)))) {
+        throw new AppError("Parâmetro 'valor_max' deve ser um número válido e positivo", 400);
+    }
+    if (Number(valor_min) > Number(valor_max)) {
+        throw new AppError("Parâmetro 'valor_min' não pode ser maior que 'valor_max'", 400);
+    }
+
+    return true;
+}
+
+function validarTipo(tipo) {
+    if (tipo && typeof tipo !== 'string') {
+        throw new AppError("Parâmetro 'tipo' deve ser uma string", 400);
+    }
+    return true;
+}
+
+module.exports = {
+    validarLimitOffset,
+    validarValores,
+    validarTipo
+};

--- a/backend/src/utils/validarParametrosDespesas.spec.js
+++ b/backend/src/utils/validarParametrosDespesas.spec.js
@@ -1,0 +1,70 @@
+
+const { validarLimitOffset, validarValores, validarTipo } = require("./validarParametrosDespesas");
+const AppError = require("../utils/AppError");
+
+describe("validarParametrosDespesas", () => {
+  describe("validarLimitOffset", () => {
+    it("deve aceitar limit e offset válidos", () => {
+      expect(() => validarLimitOffset(10, 0)).not.toThrow();
+      expect(() => validarLimitOffset("5", "2")).not.toThrow();
+      expect(() => validarLimitOffset(undefined, undefined)).not.toThrow();
+    });
+
+    it("deve lançar erro para limit negativo ou não inteiro", () => {
+      expect(() => validarLimitOffset(-1, 0)).toThrow(AppError);
+      expect(() => validarLimitOffset("-1", 0)).toThrow(AppError);
+      expect(() => validarLimitOffset("abc", 0)).toThrow(AppError);
+      expect(() => validarLimitOffset(1.5, 0)).toThrow(AppError);
+    });
+
+    it("deve lançar erro para offset negativo ou não inteiro", () => {
+      expect(() => validarLimitOffset(10, -2)).toThrow(AppError);
+      expect(() => validarLimitOffset(10, "-2")).toThrow(AppError);
+      expect(() => validarLimitOffset(10, "xyz")).toThrow(AppError);
+      expect(() => validarLimitOffset(10, 1.1)).toThrow(AppError);
+    });
+  });
+
+  describe("validarValores", () => {
+    it("deve aceitar valores válidos ou indefinidos", () => {
+      expect(() => validarValores(undefined, undefined)).not.toThrow();
+      expect(() => validarValores(0, 10)).not.toThrow();
+      expect(() => validarValores("0", "10")).not.toThrow();
+      expect(() => validarValores(5, 5)).not.toThrow();
+      expect(() => validarValores(undefined, 10)).not.toThrow();
+      expect(() => validarValores(0, undefined)).not.toThrow();
+    });
+
+    it("deve lançar erro se valor_min for negativo ou inválido", () => {
+      expect(() => validarValores(-1, 10)).toThrow(AppError);
+      expect(() => validarValores("-1", 10)).toThrow(AppError);
+      expect(() => validarValores("abc", 10)).toThrow(AppError);
+    });
+
+    it("deve lançar erro se valor_max for negativo ou inválido", () => {
+      expect(() => validarValores(0, -5)).toThrow(AppError);
+      expect(() => validarValores(0, "-5")).toThrow(AppError);
+      expect(() => validarValores(0, "xyz")).toThrow(AppError);
+    });
+
+    it("deve lançar erro se valor_min > valor_max", () => {
+      expect(() => validarValores(11, 10)).toThrow(AppError);
+      expect(() => validarValores("20", "10")).toThrow(AppError);
+    });
+  });
+
+  describe("validarTipo", () => {
+    it("deve aceitar tipo string ou indefinido", () => {
+      expect(() => validarTipo("alimentação")).not.toThrow();
+      expect(() => validarTipo(undefined)).not.toThrow();
+      expect(() => validarTipo("")).not.toThrow();
+    });
+
+    it("deve lançar erro se tipo não for string", () => {
+      expect(() => validarTipo(123)).toThrow(AppError);
+      expect(() => validarTipo({})).toThrow(AppError);
+      expect(() => validarTipo([])).toThrow(AppError);
+      expect(() => validarTipo(true)).toThrow(AppError);
+    });
+  });
+});


### PR DESCRIPTION
##  Pull Request: Listagem de despesas por deputado com filtros e paginação

### 🎯 Descrição

Esta PR implementa os filtros no endpoint `GET /despesas/deputados/:deputado_id`, permitindo a listagem paginada das despesas de um deputado específico, com suporte a diversos filtros. Também foram adicionadas funções auxiliares para validação de parâmetros e testes automatizados para garantir a robustez da funcionalidade. (Closes #24 )

### 🚀 Funcionalidades incluídas

* Criação do endpoint `GET /despesas/deputados/:deputado_id`
* Filtros disponíveis:

  * `tipo` (tipo da despesa, busca parcial)
  * `valor_min` / `valor_max`
  * `uf` (sigla do estado da despesa)
* Paginação com `limit` e `offset`
* Retorno inclui metadados:

  * `total` de registros compatíveis com os filtros
  * `limit` e `offset` utilizados
* Validações robustas para:

  * ID do deputado
  * Sigla UF
  * Valores mínimos e máximos
  * Tipos de despesas
  * Paginação (`limit` e `offset`)


### 🧪 Testes adicionados

* Testes unitários para validação de parâmetros (`valor_min`, `valor_max`, `limit`, `offset`, `tipo`)
* Testes para o método `index` do `DespesasController`, cobrindo:

  * Filtros aplicados corretamente
  * Paginação
  * Casos inválidos (ex: valores negativos, tipo inválido)


### 🧱 Estrutura técnica

* Controller: `DespesasController#index`
* Utilitários:

  * `validarParametrosDespesas.js`
  * `validarIdDeputado.js`
  * `validarSiglaUf.js`
* Rotas: adicionada à `despesasRoutes`


### ✅ Exemplo de requisição

```http
GET /despesas/deputados/204555?uf=SP&valor_min=100&tipo=alimentação&limit=5&offset=0
```

### ✅ Exemplo de resposta

```json
{
  "dados": [ ... ],
  "total": 12,
  "limit": 5,
  "offset": 0
}
```

### 🔒 Validações garantidas via código

* `deputado_id`: inteiro positivo e existente
* `limit` e `offset`: inteiros positivos
* `valor_min` e `valor_max`: números válidos e coerentes
* `tipo`: string
* `uf`: sigla válida

