### PR TITLE
Correções na função validarLimitOffset e ajustes no comportamento de paginação

### DIFF
--- a/backend/src/controllers/DespesasController.js
+++ b/backend/src/controllers/DespesasController.js
@@ -2,21 +2,23 @@ const validarIdDeputado = require('../utils/validarIdDeputado');
 const knex = require('../database/knex');
 const AppError = require('../utils/AppError');
 const validarSiglaUf = require('../utils/validarSiglaUf');
-const { validarLimitOffset, validarValores, validarTipo} = require('../utils/validarParametrosDespesas');
+const { validarLimitOffset, validarValores, validarTipo } = require('../utils/validarParametrosDespesas');
 
 class DespesasController {
 
     async index(request, response) {
         const { deputado_id } = request.params;
 
-        const { limit, offset, valor_min, valor_max, tipo, uf } = request.query;
+        const { valor_min, valor_max, tipo, uf } = request.query;
 
+        const { limit, offset } = validarLimitOffset(request.query.limit, request.query.offset);
         validarIdDeputado(deputado_id);
-        validarLimitOffset(limit, offset);
         validarValores(valor_min, valor_max);
         validarTipo(tipo);
 
-        let query = knex("despesas").where({ id_deputado: deputado_id }).orderBy("data_emissao", "desc");
+        let query = knex("despesas")
+            .select("id", 'descricao', 'valor_documento', 'data_emissao', 'fornecedor', 'sigla_uf')
+            .where({ id_deputado: deputado_id }).orderBy("data_emissao", "desc");
 
         if (uf && await validarSiglaUf(uf)) query = query.where("sigla_uf", uf);
         if (valor_min) query = query.where("valor_documento", ">=", valor_min);
@@ -24,15 +26,14 @@ class DespesasController {
         if (tipo) query = query.where("descricao", "like", `%${tipo}%`);
 
         const despesas = await query.limit(limit).offset(offset);
-        const {total} = await query.clone().count('* as total').first();
-        
+        const { total } = await query.clone().count('* as total').first();
+
         response.json({
-            dados:despesas,
-            total: total,
-            limit: Number(limit),
-            offset: Number(offset) ? Number(offset) : 0 
+            dados: despesas,
+            total: total ? Number(total) : 0,
+            limit: limit,
+            offset: offset
         });
     }
 }
-
 module.exports = DespesasController;

--- a/backend/src/utils/validarParametrosDespesas.js
+++ b/backend/src/utils/validarParametrosDespesas.js
@@ -8,7 +8,7 @@ function validarLimitOffset(limit, offset) {
     if (!/^\d+$/.test(limit) || !/^\d+$/.test(offset)) {
         throw new AppError("Parâmetros 'limit' e 'offset' devem ser números inteiros positivos", 400);
     }
-    return true;
+    return { limit: Number(limit), offset: Number(offset) };
 }
 
 function validarValores(valor_min, valor_max) {


### PR DESCRIPTION
## 🛠️ Pull Request: Correções na função `validarLimitOffset` e ajustes no comportamento de paginação

### 🎯 Descrição

Esta PR corrige o comportamento da função `validarLimitOffset`, que anteriormente não atribuía corretamente os valores padrão (`limit = 10`, `offset = 0`) quando os parâmetros não eram fornecidos, resultando na exibição de todos os registros.

Além disso, foram adicionadas correções em testes e mocks relacionados, garantindo que a paginação funcione conforme o esperado. (Closes #24 )

### ✅ Correções incluídas

* ✅ **Fix:** `validarLimitOffset` agora retorna um objeto com `limit` e `offset` corretamente definidos.
* ✅ **Fix:** Correção no `DespesasController#index` para utilizar os valores corrigidos de `limit` e `offset`, evitando a quebra da paginação.
* ✅ **Test:** Adiciona mock para `validarLimitOffset` nos testes do controller.
* ✅ **Test:** Ajustes em chamadas de testes que dependiam de paginação incorreta.


### 🧪 Exemplo de resposta agora com paginação funcional

```json
{
  "dados": [ ... ],
  "total": 120,
  "limit": 10,
  "offset": 0
}
```


### 📌 Motivação da correção

Anteriormente, a função `validarLimitOffset` realizava a verificação, mas **não retornava os valores ajustados**, o que fazia com que o controller utilizasse `undefined`, retornando todas as despesas ao invés de aplicar a paginação.

Essa PR garante consistência e evita sobrecarga no endpoint.
