### PR TITLE
Criação do endpoint de ranking de despesas dos deputados

### DIFF
--- a/backend/src/controllers/DespesasController.js
+++ b/backend/src/controllers/DespesasController.js
@@ -35,5 +35,38 @@ class DespesasController {
             offset: offset
         });
     }
+
+     async ranking(request, response) {
+
+        const { limit, offset } = validarLimitOffset(request.query.limit, request.query.offset);
+
+        const ranking = await knex("deputados")
+            .join("despesas", "despesas.id_deputado", "deputados.id")
+            .select(
+                "deputados.id as id",
+                "deputados.nome as nome",
+                "deputados.url_foto as url_foto",
+                "deputados.partido as partido",
+                "deputados.sigla_uf as uf",
+                knex.raw("SUM(despesas.valor_documento) as total_gasto")
+            )
+            .groupBy("deputados.id")
+            .orderBy("total_gasto", "desc")
+            .limit(limit)
+            .offset(offset);
+
+        // total de deputados com despesas
+        const { total } = await knex("despesas")
+            .join("deputados", "deputados.id", "despesas.id_deputado")
+            .countDistinct("deputados.id as total").first();
+
+        response.json({
+            dados: ranking,
+            total: Number(total) ? Number(total) : 0,
+            limit:limit,
+            offset: offset
+        });
+    }
+
 }
 module.exports = DespesasController;

--- a/backend/src/routes/despesas.routes.js
+++ b/backend/src/routes/despesas.routes.js
@@ -5,5 +5,6 @@ const despesasRoutes = Router();
 const despesasController = new DespesasController();
 
 despesasRoutes.get("/deputados/:deputado_id", despesasController.index);
+despesasRoutes.get("/ranking", despesasController.ranking);
 
 module.exports = despesasRoutes;


### PR DESCRIPTION
## 🚀 Pull Request: Criação do endpoint de ranking de despesas dos deputados

### 🎯 Descrição

Esta PR implementa o endpoint `GET /despesas/ranking`, responsável por exibir um ranking dos deputados que mais gastaram recursos públicos, com base no valor total das despesas registradas. (Closes #27 )

### ✅ Funcionalidades implementadas

* **Endpoint criado:** `GET /despesas/ranking`
* **Consulta** que:

  * Agrupa despesas por deputado
  * Calcula o total gasto por parlamentar (`SUM(despesas.valor_documento)`)
  * Ordena do maior para o menor gasto
  * Aplica paginação via `limit` e `offset`
* **Resposta inclui:**

  * Nome, partido, UF e foto do deputado
  * Valor total gasto
  * Total de deputados com despesas
  * Parâmetros de paginação utilizados


### 🔎 Exemplo de resposta

```json
{
  "dados": [
    {
      "id": 123,
      "nome": "Deputado Exemplo",
      "url_foto": "http://foto.exemplo.jpg",
      "partido": "ABC",
      "uf": "SP",
      "total_gasto": "35987.23"
    }
  ],
  "total": 513,
  "limit": 10,
  "offset": 0
}
```


### 📌 Considerações

* Utiliza o método `validarLimitOffset` para garantir integridade nos parâmetros de paginação.
* Serve como base para a **User Story**: *"Ranking de Gastos Parlamentares"*, permitindo à população visualizar quem mais consome recursos públicos.


### 📁 Arquivos modificados

* `DespesasController.js`: Adiciona o método `ranking`
* `despesas.routes.js`: Adiciona a rota `/despesas/ranking`