### PR TITLE
Filtros e Refatoração do Ranking de Despesas dos Deputados

### DIFF
--- a/backend/src/utils/buildRankingQuery.js
+++ b/backend/src/utils/buildRankingQuery.js
@@ -1,0 +1,32 @@
+const knex = require('../database/knex');
+const { validarMes, validarAno } = require('./validarParametrosDespesas');
+const validarPartido = require('./validarPartido');
+const validarSiglaUf = require('./validarSiglaUf');
+
+async function buildRankingQuery(query, limit, offset) {
+    const { uf, partido, mes, ano, ordem } = query;
+
+    let rankingQuery = knex('deputados')
+        .join('despesas', 'despesas.id_deputado', 'deputados.id')
+        .select(
+            'deputados.id as id',
+            'deputados.nome as nome',
+            'deputados.url_foto as url_foto',
+            'deputados.partido as partido',
+            'deputados.sigla_uf as uf',
+            knex.raw('SUM(despesas.valor_documento) as total_gasto')
+        )
+        .groupBy('deputados.id');
+
+    if (uf && await validarSiglaUf(uf)) rankingQuery = rankingQuery.where('deputados.sigla_uf', uf);
+    if (partido && await validarPartido(partido)) rankingQuery = rankingQuery.where('deputados.partido', partido);
+    if (mes && validarMes(mes)) rankingQuery = rankingQuery.where('despesas.mes', mes);
+    if (ano && validarAno(ano)) rankingQuery = rankingQuery.where('despesas.ano', ano);
+
+    const totalQuery  =  rankingQuery.clone().clearSelect().clearGroup().countDistinct('deputados.id as total');
+    const dataQuery = rankingQuery.clone().orderBy('total_gasto', ordem === 'asc' ? 'asc' : 'desc').limit(limit).offset(offset);
+
+    return { dataQuery, totalQuery };
+}
+
+module.exports = buildRankingQuery;

--- a/backend/src/utils/buildRankingQuery.spec.js
+++ b/backend/src/utils/buildRankingQuery.spec.js
@@ -1,0 +1,100 @@
+const buildRankingQuery = require('../utils/buildRankingQuery');
+const knex = require('../database/knex');
+
+jest.mock('../database/knex', () => {
+  const mockQuery = {
+    join: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    raw: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    clone: jest.fn().mockReturnThis(),
+    clearSelect: jest.fn().mockReturnThis(),
+    clearGroup: jest.fn().mockReturnThis(),
+    countDistinct: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+  };
+  const knexMock = jest.fn(() => mockQuery);
+  knexMock.raw = jest.fn().mockReturnThis();
+  return knexMock;
+});
+
+jest.mock('../utils/validarSiglaUf', () => jest.fn());
+jest.mock('../utils/validarPartido', () => jest.fn());
+jest.mock('../utils/validarParametrosDespesas', () => ({
+  validarMes: jest.fn(),
+  validarAno: jest.fn()
+}));
+
+const validarSiglaUf = require('../utils/validarSiglaUf');
+const validarPartido = require('../utils/validarPartido');
+const { validarMes, validarAno } = require('../utils/validarParametrosDespesas');
+
+describe('buildRankingQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve construir query sem filtros', async () => {
+    const query = {};
+    const result = await buildRankingQuery(query, 10, 0);
+    
+    expect(knex).toHaveBeenCalledWith('deputados');
+    expect(result.dataQuery.orderBy).toHaveBeenCalledWith('total_gasto', 'desc');
+    expect(result.dataQuery.limit).toHaveBeenCalledWith(10);
+    expect(result.dataQuery.offset).toHaveBeenCalledWith(0);
+  });
+
+  it('deve aplicar filtro por UF, partido, mês e ano', async () => {
+    validarSiglaUf.mockResolvedValue(true);
+    validarPartido.mockResolvedValue(true);
+    validarMes.mockReturnValue(true);
+    validarAno.mockReturnValue(true);
+
+    const query = {
+      uf: 'SP',
+      partido: 'PT',
+      mes: 3,
+      ano: 2023,
+      ordem: 'asc',
+    };
+
+    const result = await buildRankingQuery(query, 5, 10);
+
+    expect(validarSiglaUf).toHaveBeenCalledWith('SP');
+    expect(validarPartido).toHaveBeenCalledWith('PT');
+    expect(validarMes).toHaveBeenCalledWith(3);
+    expect(validarAno).toHaveBeenCalledWith(2023);
+
+    expect(result.dataQuery.orderBy).toHaveBeenCalledWith('total_gasto', 'asc');
+    expect(result.dataQuery.limit).toHaveBeenCalledWith(5);
+    expect(result.dataQuery.offset).toHaveBeenCalledWith(10);
+  });
+
+  it('deve ignorar filtro se UF inválida', async () => {
+    validarSiglaUf.mockResolvedValue(false);
+
+    const query = {
+      uf: 'XX',
+    };
+
+    const result = await buildRankingQuery(query, 5, 0);
+
+    expect(validarSiglaUf).toHaveBeenCalledWith('XX');
+    expect(result.dataQuery.where).not.toHaveBeenCalledWith('deputados.sigla_uf', 'XX');
+  });
+
+  it('deve ordenar descendente por padrão', async () => {
+    const query = {};
+    const result = await buildRankingQuery(query, 10, 0);
+    expect(result.dataQuery.orderBy).toHaveBeenCalledWith('total_gasto', 'desc');
+  });
+
+  it('deve ordenar ascendente se passado', async () => {
+    const query = { ordem: 'asc' };
+    const result = await buildRankingQuery(query, 10, 0);
+    expect(result.dataQuery.orderBy).toHaveBeenCalledWith('total_gasto', 'asc');
+  });
+});

--- a/backend/src/utils/validarParametrosDespesas.js
+++ b/backend/src/utils/validarParametrosDespesas.js
@@ -32,8 +32,25 @@ function validarTipo(tipo) {
     return true;
 }
 
+
+function validarMes(mes) {
+    if (mes && (Number(mes) < 1 || Number(mes) > 12 || isNaN(Number(mes)))) {
+        throw new AppError("Parâmetro 'mes' deve ser um número entre 1 e 12", 400);
+    }
+    return true;
+}
+
+function validarAno(ano) {
+    if (ano && (Number(ano) < 2023 || Number(ano) > new Date().getFullYear() || isNaN(Number(ano)))) {
+        throw new AppError("Parâmetro 'ano' deve ser um número válido entre 2023 e o ano atual", 400);
+    }
+    return true;
+}
+
 module.exports = {
     validarLimitOffset,
     validarValores,
-    validarTipo
+    validarTipo,
+    validarMes,
+    validarAno
 };


### PR DESCRIPTION
## 🚀 Pull Request: Filtros e Refatoração do Ranking de Despesas dos Deputados

### 🎯 Descrição

Esta PR **refatora o método `ranking`** do `DespesasController` para usar uma função externa (`buildRankingQuery`) que constrói dinamicamente a consulta SQL, permitindo adicionar **filtros por UF, partido, mês, ano e ordem** de forma validada e escalável. (Closes #28 )


### ✅ Funcionalidades implementadas

* ✅ Refatoração do método `ranking` para utilizar `buildRankingQuery`
* ✅ Adição dos filtros:

  * `uf`: sigla do estado
  * `partido`: partido político
  * `mes`: mês de referência (1-12)
  * `ano`: ano de referência (a partir de 2023 até o ano atual)
  * `ordem`: ordenação do ranking (`asc` ou `desc`)
* ✅ Validações aplicadas aos filtros, com tratamento de erros apropriado
* ✅ Paginação com `limit` e `offset` mantida
* ✅ Cálculo preciso do total de deputados com despesas após aplicação dos filtros
* ✅ Testes unitários para:

  * `DespesasController.ranking`
  * `buildRankingQuery`
  * Validações de `mes` e `ano`


### 📁 Arquivos modificados / adicionados

#### ♻️ Refatorados

* `DespesasController.js`
* `validarParametrosDespesas.js`

#### 🧪 Novos suítes de teste

* `DespesasController.spec.js` - Método Ranking
* `buildRankingQuery.spec.js`

#### 🆕 Novos utilitários

* `buildRankingQuery.js`


### 🔒 Validações incluídas

* `validarMes(mes: number)`: entre 1 e 12
* `validarAno(ano: number)`: entre 2023 e o ano atual

### 🔎 Exemplo de uso

`GET /despesas/ranking?partido=PT&uf=SP&mes=3&ano=2023&ordem=asc&limit=10&offset=0`


### 🧪 Testes

Cobertura de testes para:

* Resposta com filtros válidos
* Casos com valores ausentes ou inválidos
* Tratamento de exceções no banco de dados
* Verificação dos parâmetros passados para o `knex`
